### PR TITLE
Contact Form 7が無効になっているときにプラグインを有効化した際に警告メッセージを表示しないように調整

### DIFF
--- a/includes/class-kintone-form-admin.php
+++ b/includes/class-kintone-form-admin.php
@@ -192,10 +192,12 @@ class Kintone_Form_Admin {
 
 		add_filter( 'wpcf7_editor_panels', array( $this, 'wpcf7_editor_panels' ) );
 		add_filter( 'wpcf7_contact_form_properties', array( $this, 'wpcf7_contact_form_properties' ), 10, 2 );
-		if ( version_compare( WPCF7_VERSION, '5.5.3', '>=' ) ) {
-			add_filter( 'wpcf7_pre_construct_contact_form_properties', array( $this, 'wpcf7_contact_form_properties' ), 10, 2 );
-		} else {
-			add_filter( 'wpcf7_contact_form_properties', array( $this, 'wpcf7_contact_form_properties' ), 10, 2 );
+		if ( defined( 'WPCF7_VERSION' ) ) {
+			if ( version_compare( WPCF7_VERSION, '5.5.3', '>=' ) ) {
+				add_filter( 'wpcf7_pre_construct_contact_form_properties', array( $this, 'wpcf7_contact_form_properties' ), 10, 2 );
+			} else {
+				add_filter( 'wpcf7_contact_form_properties', array( $this, 'wpcf7_contact_form_properties' ), 10, 2 );
+			}
 		}
 
 		add_action( 'wpcf7_admin_init', array( $this, 'kintone_form_add_tag_generator_text' ) );


### PR DESCRIPTION
バージョン2.22.0で取り込んでいただいたContact form 7 5.5.3に対応するパッチにおいて一部未考慮の点がありました。

Contact Form 7が無効になっているときにプラグインを有効化しようとするとPHPの警告メッセージが管理画面上に表示されてしまう状況になってしまっていたので、警告メッセージが表示されないように調整しました。