### PR TITLE
Contact Form 7のその他の設定でdo_not_store: trueもしくはdemo_mode: onを指定した際にメッセージ保存を抑制するように調整

### DIFF
--- a/includes/class-kintone-form-post-kintone.php
+++ b/includes/class-kintone-form-post-kintone.php
@@ -138,6 +138,10 @@ class Kintone_Form_Post_Kintone {
 
 		} else {
 
+			if ( $contact_form->is_true( 'demo_mode' ) || $contact_form->is_true( 'do_not_store' ) ) {
+				return;
+			}
+
 			// 1フォームで複数アプリを登録する時に紐付けるキーに利用
 			$unique_key = '';
 			$unique_key = apply_filters( 'form_data_to_kintone_get_unique_key', $unique_key );

--- a/includes/class-kintone-form-post-kintone.php
+++ b/includes/class-kintone-form-post-kintone.php
@@ -54,6 +54,10 @@ class Kintone_Form_Post_Kintone {
 	 */
 	public function kintone_form_send( $contact_form ) {
 
+		if ( $contact_form->is_true( 'demo_mode' ) || $contact_form->is_true( 'do_not_store' ) ) {
+			return;
+		}
+
 		$submission = WPCF7_Submission::get_instance();
 		if ( empty( $submission ) ) {
 			return;
@@ -137,10 +141,6 @@ class Kintone_Form_Post_Kintone {
 			$this->erro_mail( $e, $kintone_setting_data['email_address_to_send_kintone_registration_error'] );
 
 		} else {
-
-			if ( $contact_form->is_true( 'demo_mode' ) || $contact_form->is_true( 'do_not_store' ) ) {
-				return;
-			}
 
 			// 1フォームで複数アプリを登録する時に紐付けるキーに利用
 			$unique_key = '';


### PR DESCRIPTION
https://contactform7.com/ja/additional-settings/ で言及されている「do_not_store: true」もしくは「demo_mode: on」をContact Form 7の「その他の設定」で指定した際にkintoneへのデータ送信を抑止するように調整するためのプルリクエストです。